### PR TITLE
Unit tests failing for JS API when Airbrake env values are empty

### DIFF
--- a/src/test-utils/global-setup.js
+++ b/src/test-utils/global-setup.js
@@ -14,5 +14,8 @@ export default async () => {
 
   process.env.BASE_URL = 'http://localhost:5000'
 
+  process.env.AIRBRAKE_PROJECT_KEY = 'key'
+  process.env.AIRBRAKE_HOST = 'host'
+
   logger.info('\nDatabase host set to localhost')
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5033

Unit tests failing for JS API when Airbrake env values are empty