### PR TITLE
Update Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ To run the service:
 npm run docker:service-dev
 ```
 
-To stop the running ther service
+If you are a Mac user, you may receive an error that something is already running on port 5000. This can be fixed by going into your system settings and disabling Airplay Receiver.
+
+To stop running the service:
 
 ```shell script
 npm run docker:stop-dev
@@ -135,7 +137,7 @@ To run the service:
 npm run docker:service
 ```
 
-To stop the running ther service
+To stop running the service:
 
 ```shell script
 npm run docker:stop


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5007

Node 20.17.0 is dropping out of support, so we need to upgrade to a newer version.